### PR TITLE
Add the .env.dist file extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to the "dotenv" extension will be documented in this file.
 
+## 1.2.0
+### Added
+- Added support for the `.env.dist` file extension (e.g. Symfony)
+
 ## 1.1.0
 ### Added
 - [#2](https://github.com/mikestead/vscode-dotenv/issues/2) Added support for more .env file extensions

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
                     ".env.staging",
                     ".env.staging.local",
                     ".env.production",
-                    ".env.production.local"
+                    ".env.production.local",
+                    ".env.dist"
                 ],
                 "configuration": "./language-configuration.json"
             }

--- a/syntaxes/env.YAML-tmLanguage
+++ b/syntaxes/env.YAML-tmLanguage
@@ -2,7 +2,7 @@
 ---
 name: DotENV
 scopeName: source.env
-fileTypes: [".env", ".env-sample", ".env.example", ".env.local", ".env.dev", ".env.test", ".env.testing", ".env.production"]
+fileTypes: [".env", ".env-sample", ".env.example", ".env.local", ".env.dev", ".env.test", ".env.testing", ".env.production", ".env.dist"]
 uuid: 09d4e117-0975-453d-a74b-c2e525473f97
 
 patterns:

--- a/syntaxes/env.tmLanguage
+++ b/syntaxes/env.tmLanguage
@@ -16,6 +16,7 @@
       <string>.env.test</string>
       <string>.env.testing</string>
       <string>.env.production</string>
+      <string>.env.dist</string>
     </array>
     <key>uuid</key>
     <string>09d4e117-0975-453d-a74b-c2e525473f97</string>


### PR DESCRIPTION
Symfony for example uses the `.env.dist` file extension for the distributed environment variable file, so I think it's a good idea to support this file extension by default.