### PR TITLE
Adding Support for .env.prod ( For Ionic App Scripts Build )

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
                     ".env.staging",
                     ".env.staging.local",
                     ".env.production",
-                    ".env.production.local"
+                    ".env.production.local",
+                    ".env.prod"
                 ],
                 "configuration": "./language-configuration.json"
             }

--- a/syntaxes/env.YAML-tmLanguage
+++ b/syntaxes/env.YAML-tmLanguage
@@ -2,7 +2,7 @@
 ---
 name: DotENV
 scopeName: source.env
-fileTypes: [".env", ".env-sample", ".env.example", ".env.local", ".env.dev", ".env.test", ".env.testing", ".env.production"]
+fileTypes: [".env", ".env-sample", ".env.example", ".env.local", ".env.dev", ".env.test", ".env.testing", ".env.production", ".env.prod"]
 uuid: 09d4e117-0975-453d-a74b-c2e525473f97
 
 patterns:

--- a/syntaxes/env.tmLanguage
+++ b/syntaxes/env.tmLanguage
@@ -16,6 +16,7 @@
       <string>.env.test</string>
       <string>.env.testing</string>
       <string>.env.production</string>
+      <string>.env.prod</string>
     </array>
     <key>uuid</key>
     <string>09d4e117-0975-453d-a74b-c2e525473f97</string>


### PR DESCRIPTION
Ionic-app-scripts build process use --prod flag which will pick up .env.prod file, adding Syntax highlight support for the same.