### PR TITLE
added .env.template

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
                     ".env",
                     ".env-sample",
                     ".env.example",
+                    ".env.template",
                     ".env.local",
                     ".env.dev",
                     ".env.dev.local",

--- a/syntaxes/env.YAML-tmLanguage
+++ b/syntaxes/env.YAML-tmLanguage
@@ -2,7 +2,7 @@
 ---
 name: DotENV
 scopeName: source.env
-fileTypes: [".env", ".env-sample", ".env.example", ".env.local", ".env.dev", ".env.test", ".env.testing", ".env.production", ".env.prod"]
+fileTypes: [".env", ".env-sample", ".env.example", ".env.template", ".env.local", ".env.dev", ".env.test", ".env.testing", ".env.production", ".env.prod"]
 uuid: 09d4e117-0975-453d-a74b-c2e525473f97
 
 patterns:

--- a/syntaxes/env.tmLanguage
+++ b/syntaxes/env.tmLanguage
@@ -11,6 +11,7 @@
       <string>.env</string>
       <string>.env-sample</string>
       <string>.env.example</string>
+      <string>.env.template</string>
       <string>.env.local</string>
       <string>.env.dev</string>
       <string>.env.test</string>


### PR DESCRIPTION
I believe `.env.template` is reasonable and good name for .env files and in some cases might be more suitable than .sample, .defaults, .example, .schema etc. Could we add it to recognized pattern?