### PR TITLE
Improve language detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "vscode": "^1.5.1"
     },
     "categories": [
-        "Languages"
+        "Programming Languages"
     ],
     "keywords": [
         "env",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,12 @@
                     ".env.prod",
                     ".env.prod.local"
                 ],
+                "filenamePatterns": [
+                    "?*env"
+                ],
+                "filenames": [
+                    "env"
+                ],
                 "configuration": "./language-configuration.json"
             }
         ],


### PR DESCRIPTION
There is a large number of dotenv files out there that do not actually use a dot in their name. Here is a small comparative study:

| glob pattern | hits on public GitHub repositories |
| --- | --: |
| `env` | [2.8k](https://sourcegraph.com/search?q=context:global+file:/env%24+count:100000&patternType=literal) |
| `*.env` | [29.1k](https://sourcegraph.com/search?q=context:global+file:/.*%5C.env%24+count:100000&patternType=literal) |
| `?*env` | [12.5k](https://sourcegraph.com/search?q=context:global+file:/.*%5B%5E.%5Denv%24+count:100000&patternType=literal) |
| `env_*` | [0.635k](https://sourcegraph.com/search?q=context:global+file:/env_%5B%5E./%5D%2B%24+count:100000&patternType=literal) |

For more information on the study, see: https://github.com/squeak-smalltalk/squeak-app/pull/22#discussion_r721667361

Additionally, this PR updates the extension category according to a deprecation warning generated by VS Code (9e0e233).