### PR TITLE
only higlight "export" when there is a whitespace after the keyword

### DIFF
--- a/syntaxes/env.tmLanguage
+++ b/syntaxes/env.tmLanguage
@@ -125,7 +125,7 @@
         <key>comment</key>
         <string>Keywords</string>
         <key>match</key>
-        <string>(?i)\s?(export)</string>
+        <string>(?i)\s?(export )</string>
         <key>name</key>
         <string>keyword.other.env</string>
       </dict>


### PR DESCRIPTION
now the keyword only get highlighted when it is in front if a declaration and not mid word od variable name